### PR TITLE
Fix header when auth missing

### DIFF
--- a/tests/backend/utils/fetchers.test.ts
+++ b/tests/backend/utils/fetchers.test.ts
@@ -76,6 +76,28 @@ describe('fetchers', () => {
       );
       expect(result).toEqual({ fallback: true });
     });
+
+    it('omits Authorization header when no session is returned', async () => {
+      vi.mocked(auth).mockResolvedValue(null as any);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ noAuth: true }),
+      });
+
+      const result = await fetchData('no-auth');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:4000/api/no-auth',
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'Content-type': 'application/json',
+          },
+          cache: 'no-store',
+        })
+      );
+      expect(result).toEqual({ noAuth: true });
+    });
   });
 
   describe('sendData', () => {

--- a/utils/fetchers.ts
+++ b/utils/fetchers.ts
@@ -3,12 +3,17 @@ import { auth } from '@/auth';
 export const fetchData = async (params: string) => {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const session = await auth();
+  const headers: Record<string, string> = {
+    'Content-type': 'application/json',
+  };
+
+  if (session?.accessToken) {
+    headers.Authorization = `Bearer ${session.accessToken}`;
+  }
+
   const res = await fetch(`${baseUrl}/api/${params}`, {
     method: 'GET',
-    headers: {
-      'Content-type': 'application/json',
-      Authorization: `Bearer ${session?.accessToken}`,
-    },
+    headers,
     cache: 'no-store',
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- ensure `fetchData` doesn't send an undefined Authorization header
- test that Authorization is omitted when session is missing

## Testing
- `npx vitest --project backend tests/backend/utils/fetchers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6843c78510b48331b0104725921fa6ff