### PR TITLE
Fix/2838 remove date from certain statuses AB#2838

### DIFF
--- a/components/Fields/DetailsField.tsx
+++ b/components/Fields/DetailsField.tsx
@@ -4,6 +4,7 @@ import { getDetailsPlaceholder } from '@/components/AppContent';
 import { UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 import { formSchema } from '@/components/StatusForm/StatusForm';
+import { useEffect } from 'react';
 
 type DetailsFieldProps = {
   form: UseFormReturn<z.infer<typeof formSchema>>;
@@ -11,6 +12,12 @@ type DetailsFieldProps = {
 
 export function DetailsField({ form }: DetailsFieldProps) {
   const chosenStatus = form.watch('status');
+
+  useEffect(() => {
+    if (chosenStatus !== 'ON_LEAVE' && chosenStatus !== 'VACATION') {
+      form.setValue('dateRange', undefined);
+    }
+  }, [form, chosenStatus]);
 
   if (chosenStatus !== 'SICK' && chosenStatus !== undefined) {
     return (

--- a/components/StatusForm/StatusForm.tsx
+++ b/components/StatusForm/StatusForm.tsx
@@ -98,19 +98,22 @@ export function StatusForm({
     if (!userId) return;
 
     try {
-      const newStatus = await createNewStatusAction({
-        userID: userId,
-        status: values.status,
-        details: values.detailsString,
-        time:
-          values.status === 'SICK'
-            ? null
-            : values.actionTime
-              ? timeStringToDate(values.actionTime)
-              : null,
-        fromDate: values?.status === 'SICK' ? undefined : values.dateRange?.from,
-        toDate: values?.status === 'SICK' ? undefined : values.dateRange?.to,
-      });
+      let newStatus;
+      if (values.status === 'SICK') {
+        newStatus = await createNewStatusAction({
+          userID: userId,
+          status: values.status,
+        });
+      } else {
+        newStatus = await createNewStatusAction({
+          userID: userId,
+          status: values.status,
+          details: values.detailsString,
+          time: values.actionTime ? timeStringToDate(values.actionTime) : null,
+          fromDate: values.dateRange?.from,
+          toDate: values.dateRange?.to,
+        });
+      }
 
       if (newStatus && newStatus.status) {
         if (setOpenSidebar) {

--- a/components/StatusForm/StatusForm.tsx
+++ b/components/StatusForm/StatusForm.tsx
@@ -102,9 +102,14 @@ export function StatusForm({
         userID: userId,
         status: values.status,
         details: values.detailsString,
-        time: values.actionTime ? timeStringToDate(values.actionTime) : null,
-        fromDate: values.dateRange?.from,
-        toDate: values.dateRange?.to,
+        time:
+          values.status === 'SICK'
+            ? null
+            : values.actionTime
+              ? timeStringToDate(values.actionTime)
+              : null,
+        fromDate: values?.status === 'SICK' ? undefined : values.dateRange?.from,
+        toDate: values?.status === 'SICK' ? undefined : values.dateRange?.to,
       });
 
       if (newStatus && newStatus.status) {


### PR DESCRIPTION
# 🐛 Error
We need to make sure that if  a status within the same session is first set to `VACATION` and then to e.g. `AT_CLIENT`, that the dateRange is removed. 

also we need to make sure if status us set to `SICK` then we only set the status prop


# ✅ Solution
- added checks for certain status types and based on that removed certain values or sets them to undefined. 
- added a separate create call for `status === "SICK" `

