### PR TITLE
fix: set default value for detailsString in status form

### DIFF
--- a/components/StatusForm/StatusForm.tsx
+++ b/components/StatusForm/StatusForm.tsx
@@ -22,7 +22,7 @@ const dateRangeSchema = z.object({
 export const formSchema = z
   .object({
     status: z.enum(userStatus.enumValues),
-    detailsString: z.string().optional(),
+    detailsString: z.string().default('').optional(),
     actionTime: z.string().time().optional(),
     dateRange: dateRangeSchema.optional(),
   })


### PR DESCRIPTION
details feltet manglede en default value, som gjorde at Next smed en fejl:
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/53293e5e-7dba-4ad8-8a94-269c5cd5b6e7" />
