### PR TITLE
refactor: removed caching for everything except profile-page

### DIFF
--- a/lib/services/statusService.ts
+++ b/lib/services/statusService.ts
@@ -1,4 +1,3 @@
-import { userService } from './userService';
 import { NewStatus } from '@/db/types';
 import { status } from '@/db/schema';
 import { db } from '@/db';
@@ -63,11 +62,6 @@ export const statusService = {
       });
     }
     // Re-fetch the updated user with extras
-    const updatedUser = await userService.getUserById(newStatus.userID);
-    if (updatedUser) {
-      updatedUser.status = createdStatus[0];
-      userService.updateUserInAllUsersCache(updatedUser);
-    }
     return createdStatus[0];
   },
 
@@ -85,11 +79,6 @@ export const statusService = {
         payload: {},
       });
     }
-    // Re-fetch the updated user with extras
-    const updatedUser = await userService.getUserById(userID);
-    if (updatedUser) {
-      userService.updateUserInAllUsersCache(updatedUser);
-    }
     return updated[0];
   },
 
@@ -103,11 +92,6 @@ export const statusService = {
         payload: {},
       });
     }
-    // Re-fetch the updated user with extras
-    const updatedUser = await userService.getUserById(deleted[0].userID);
-    if (updatedUser) {
-      userService.updateUserInAllUsersCache(updatedUser);
-    }
     return deleted[0];
   },
 
@@ -119,11 +103,6 @@ export const statusService = {
         event: 'status_updated',
         payload: {},
       });
-    }
-    // Re-fetch the updated user with extras
-    const updatedUser = await userService.getUserById(deleted[0].userID);
-    if (updatedUser) {
-      userService.updateUserInAllUsersCache(updatedUser);
     }
     return deleted[0];
   },

--- a/lib/services/userService.ts
+++ b/lib/services/userService.ts
@@ -28,29 +28,15 @@ const s3 = new S3Client({
   },
 });
 
-const CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
+const userCache = new Map();
 
-type CacheEntry<T> = { value: T; expiresAt: number };
-const userCache = new Map<string, CacheEntry<UserWithExtras | null>>();
-const userWithExtraCache = new Map<string, CacheEntry<UserWithExtras[] | null>>();
-
-const updateUserInAllUsersCache = (updatedUser: UserWithExtras) => {
-  for (const [cacheKey, entry] of userWithExtraCache.entries()) {
-    if (cacheKey.startsWith('userService:getAllUsers')) {
-      if (entry && entry.value) {
-        const idx = entry.value.findIndex((u) => u.userId === updatedUser.userId);
-        if (idx !== -1) {
-          entry.value[idx] = updatedUser;
-          entry.expiresAt = Date.now() + CACHE_TTL;
-        }
-      }
-    }
-  }
+const invalidateUserCache = (userId: string) => {
+  userCache.delete(userId);
 };
 
 export const userService = {
-  // Cache helper
-  updateUserInAllUsersCache,
+  // Cache invalidation function
+  invalidateUserCache,
   // GET METHODS
   async getUserByEmail(email: string) {
     const userArr = await db.select().from(users).where(eq(users.email, email)).limit(1);
@@ -105,6 +91,10 @@ export const userService = {
   },
 
   async getUserById(id: string) {
+    if (userCache.has(id)) {
+      return userCache.get(id);
+    }
+
     const userArr = await db.select().from(users).where(eq(users.userId, id)).limit(1);
     const user = userArr[0];
     if (!user) return null;
@@ -153,15 +143,12 @@ export const userService = {
       businessPhoneNumber,
       organisation: organisation?.organisationName ?? null,
     };
+
+    userCache.set(id, result);
     return result;
   },
 
   async getAllUsers(sortByStatus: boolean = true) {
-    const cacheKey = `userService:getAllUsers`;
-    const cached = userWithExtraCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) {
-      return cached.value || [];
-    }
     // 1. Fetch all users
     const usersList = await db.select().from(users).orderBy(users.firstName, users.lastName);
 
@@ -248,11 +235,6 @@ export const userService = {
         return 0;
       });
     }
-
-    userWithExtraCache.set(cacheKey, {
-      value: usersWithExtras,
-      expiresAt: Date.now() + CACHE_TTL,
-    });
 
     return usersWithExtras;
   },
@@ -405,7 +387,7 @@ export const userService = {
       const updatedUser = await userService.getUserById(user[0].userId);
       if (updatedUser) {
         updatedUser.profilePicture = url;
-        userService.updateUserInAllUsersCache(updatedUser);
+        invalidateUserCache(updatedUser.userId);
       }
       return user[0];
     } catch (err) {


### PR DESCRIPTION
Removed caching in getAllUsers, since we agreed that it is silly for a websocket solution to have cached data, because when will the client ever sit and just refresh?

The caching has been moved to the getUserById(), which we use for the profile page.
Here it will:
Cache ur user-data for profile-page when you access it
If you change your profile picture it will invalidate it