### PR TITLE
Fix: Login page styling broken

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -148,9 +148,9 @@ export async function middleware(request: NextRequest) {
 }
 
 // Configure the middleware to run on all paths except static assets
-// export const config = {
-//   matcher: [
-//     // Apply to all routes except for static assets
-//     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-//   ],
-// };
+export const config = {
+  matcher: [
+    // Apply to all routes except for static assets
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
# 🐛 Error
Login page looked like this:
<img width="996" alt="image" src="https://github.com/user-attachments/assets/5a178775-0181-4b4a-83a6-8b6b31e3b99a" />



# ✅ Solution
added the static serving of files to the middleware
<img width="995" alt="image" src="https://github.com/user-attachments/assets/abde19d8-26bb-4dd3-be86-612f6e5fdef9" />
